### PR TITLE
bug fix: Can't get the last value if header end with white space.

### DIFF
--- a/csv_files/badHeader.csv
+++ b/csv_files/badHeader.csv
@@ -1,0 +1,4 @@
+header1, header2, header3 
+line1, 1, 1.2
+line2, 2, 2.3
+line3, 3, 3.4

--- a/csvtag.go
+++ b/csvtag.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"reflect"
 	"strconv"
+	"strings"
 )
 
 // Config struct to pass to the Load function
@@ -65,6 +66,7 @@ func readFile(path string, separator rune, header []string) (map[string]int, [][
 	// We need to read it all at once to have the number of records
 	reader := csv.NewReader(file) // Create the csv reader
 	reader.TrimLeadingSpace = true
+
 	if separator != 0 {
 		reader.Comma = separator
 	}
@@ -86,7 +88,7 @@ func readFile(path string, separator rune, header []string) (map[string]int, [][
 	}
 	headerMap := make(map[string]int) // Create map
 	for i, name := range rawHeader {
-		headerMap[name] = i
+		headerMap[strings.TrimSpace(name)] = i
 	}
 	// Return our header and content
 	return headerMap, content, nil

--- a/csvtag_test.go
+++ b/csvtag_test.go
@@ -33,6 +33,17 @@ func TestValideFile(t *testing.T) {
 	}
 }
 
+func TestBadHeader(t *testing.T) {
+	tabT := []test{}
+	err := Load(Config{
+		Path: "csv_files/badHeader.csv",
+		Dest: &tabT,
+	})
+	if err != nil || checkValues(tabT) {
+		t.Fail()
+	}
+}
+
 func TestMissATag(t *testing.T) {
 	tabT := []testNoID{}
 	err := Load(Config{


### PR DESCRIPTION
hi, As you can see, if the cvs file's header end with white space, the lib can't load the last value correctly. i fix it with `strings.TrimSpace()` and the test case is provided.