### PR TITLE
GoDoc reference

### DIFF
--- a/csvtag.go
+++ b/csvtag.go
@@ -22,10 +22,10 @@ type Config struct {
 // Example:
 // 	tabT := []Test{}
 // 	err  := Load(Config{
-// 			path: "csv_files/valid.csv",
-// 			dest: &tabT,
-// 			separator: ';',
-// 			header: []string{"header1", "header2", "header3"}
+// 			Path: "csv_files/valid.csv",
+// 			Dest: &tabT,
+// 			Separator: ';',
+// 			Header: []string{"header1", "header2", "header3"}
 // 		})
 // The 'separator' and 'header' properties of the config object are optionals
 // @param dest: object where to store the result


### PR DESCRIPTION
I just noticed that the godoc reference was referencing the example you have in
the source code. I capitalized the field names so that it matches the README