### PR TITLE
Trim spaces before parsing values

### DIFF
--- a/csv_files/trailingSpaces.csv
+++ b/csv_files/trailingSpaces.csv
@@ -1,0 +1,4 @@
+header1, header2, header3
+line1, 1, 1.2                
+line2, 2, 2.3                
+line3, 3, 3.4                

--- a/load.go
+++ b/load.go
@@ -192,6 +192,7 @@ func mapToDestination(header []string, content [][]string, destination interface
 // @param valRv: the reflected value where we want to store our value.
 // @return an error if one occurs.
 func storeValue(rawValue string, valRv reflect.Value) error {
+	rawValue = strings.TrimSpace(rawValue)
 	switch valRv.Kind() {
 	case reflect.String:
 		valRv.SetString(rawValue)
@@ -201,7 +202,6 @@ func storeValue(rawValue string, valRv reflect.Value) error {
 		value, err := strconv.ParseInt(rawValue, 10, 64)
 		if err != nil && rawValue != "" {
 			return fmt.Errorf("error parsing int '%v':\n	==> %v", rawValue, err)
-
 		}
 		valRv.SetInt(value)
 	case reflect.Float64:

--- a/load_test.go
+++ b/load_test.go
@@ -79,6 +79,14 @@ func TestWithSemicolon(t *testing.T) {
 	}
 }
 
+func TestWithTrailingSpaces(t *testing.T) {
+	tabT := []test{}
+	err := LoadFromPath("csv_files/trailingSpaces.csv", &tabT)
+	if err != nil || checkValues(tabT) {
+		t.Fail()
+	}
+}
+
 func TestToMutchOptions(t *testing.T) {
 	tabT := []test{}
 	err := LoadFromPath(


### PR DESCRIPTION
Fix #17 

Not sure if we should trim all types (including strings) or only integers and floats.