### PR TITLE
Added BOM support

### DIFF
--- a/csv_files/valid_bom.csv
+++ b/csv_files/valid_bom.csv
@@ -1,0 +1,4 @@
+﻿header1, header2, header3
+line1, 1, 1.2
+line2, 2, 2.3
+line3, 3, 3.4

--- a/load_test.go
+++ b/load_test.go
@@ -55,6 +55,14 @@ func TestValideFile(t *testing.T) {
 	}
 }
 
+func TestValideFileWithBOM(t *testing.T) {
+	tabT := []test{}
+	err := LoadFromPath("csv_files/valid_bom.csv", &tabT)
+	if err != nil || checkValues(tabT) {
+		t.Fail()
+	}
+}
+
 func TestBool(t *testing.T) {
 	tabT := []testBool{}
 	err := LoadFromPath("csv_files/bool.csv", &tabT)


### PR DESCRIPTION
Now skipping the Byte Order Mark (BOM) if it exists. Old version would include the BOM in the first header field, so it would not match the specified fields correctly.